### PR TITLE
Update Readme command from rm to remove

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -52,7 +52,7 @@ Once finished the following executables will be available
 * autopsy start - starts the vm
 * autopsy stop - stops the vm
 * autopsy status - gets vm status
-* autopsy rm - removes vm
+* autopsy remove - removes vm
 * autopsy ssh - use exactly as you would ssh, provides a tunnel from a server to locally installed vm
 * autopsy - provides the CLI proxy to mdb in the vm
 


### PR DESCRIPTION
Was trying out autopsy and noticed that the Readme says `rm` for removing the vm and the command seems to be `remove`. Thanks!
